### PR TITLE
Allow undefined targetElement

### DIFF
--- a/projects/ngx-popperjs/src/lib/ngx-popperjs/ngx-popperjs.directive.ts
+++ b/projects/ngx-popperjs/src/lib/ngx-popperjs/ngx-popperjs.directive.ts
@@ -196,7 +196,7 @@ export class NgxPopperjsDirective implements OnInit, OnDestroy {
     styles: object;
 
     @Input("popperTarget")
-    targetElement: HTMLElement;
+    targetElement: HTMLElement | undefined;
 
     @Input("popperTimeoutAfterShow")
     timeoutAfterShow: number = 0;


### PR DESCRIPTION
According to the current implementation, targetElement can be null, but the type definition does not allow it.