### PR TITLE
fix: export NGX_POPPERJS_DEFAULTS token

### DIFF
--- a/projects/ngx-popperjs/src/public-api.ts
+++ b/projects/ngx-popperjs/src/public-api.ts
@@ -8,6 +8,7 @@ export * from "./lib/components/ngx-popperjs-content/ngx-popperjs-content.compon
 export * from "./lib/directives/ngx-popperjs/ngx-popperjs.directive";
 export * from "./lib/directives/ngx-popperjs/ngx-popperjs-loose.directive";
 // Models
+export * from "./lib/models/ngx-popperjs-defaults.model";
 export * from "./lib/models/ngx-popperjs-options.model";
 export * from "./lib/models/ngx-popperjs-placements.model";
 export * from "./lib/models/ngx-popperjs-triggers.model";


### PR DESCRIPTION
Hi @tonysamperi!
thanks for your work!

I'm extending the `NgxPopperjsContentComponent` and `NgxPopperjsDirective` to customize them
and I'm needing `NGX_POPPERJS_DEFAULTS` to Inject the Options to the Directive constructor.

Thanks again!